### PR TITLE
Validate subargs when dealing with array

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ matches([1, 2])(
 )
 
 matches([1])(
-  (a, b,  tail)      => 'Will not match here',
-  (a = 2, tail = []) => 'Will not match here',
-  (a = 1, tail)      => 'Will match here, b = []'
+  (a, b,  tail)       => 'Will not match here',
+  (a = 2, tail = [])  => 'Will not match here',
+  (a = 1, tail = [])  => 'Will match here, b = []'
 )
 ```
 

--- a/src/matchArray.js
+++ b/src/matchArray.js
@@ -9,7 +9,7 @@ module.exports = (currentMatch, subjectToMatch) => {
   )
 
   if (subjectToMatch.length < matchArgs.length) {
-    const matchOnSubArg = (arg, toMatch) => arg.value
+    const matchOnSubArg = (arg, toMatch) => 'value' in arg
       ? deepEqual(arg.value, toMatch)
       : true
 

--- a/src/matchArray.js
+++ b/src/matchArray.js
@@ -17,8 +17,7 @@ module.exports = (currentMatch, subjectToMatch) => {
       .slice(0, matchArgs.length - 1)
       .every((arg, index) => matchOnSubArg(arg, subjectToMatch[index]))
 
-    if (deepEqual(matchArgs[matchArgs.length - 1].value, [])
-        && matchAllSubArgs) {
+    if (deepEqual(matchArgs[matchArgs.length - 1].value, []) && matchAllSubArgs) {
       return option.Some(subjectToMatch[0])
     }
 

--- a/src/matchArray.js
+++ b/src/matchArray.js
@@ -9,7 +9,16 @@ module.exports = (currentMatch, subjectToMatch) => {
   )
 
   if (subjectToMatch.length < matchArgs.length) {
-    if (deepEqual(matchArgs[matchArgs.length - 1].value, [])) {
+    const matchOnSubArg = (arg, toMatch) => arg.value
+      ? deepEqual(arg.value, toMatch)
+      : true
+
+    const matchAllSubArgs = matchArgs
+      .slice(0, matchArgs.length - 1)
+      .every((arg, index) => matchOnSubArg(arg, subjectToMatch[index]))
+
+    if (deepEqual(matchArgs[matchArgs.length - 1].value, [])
+        && matchAllSubArgs) {
       return option.Some(subjectToMatch[0])
     }
 

--- a/src/matchArray.js
+++ b/src/matchArray.js
@@ -17,7 +17,7 @@ module.exports = (currentMatch, subjectToMatch) => {
       .slice(0, matchArgs.length - 1)
       .every((arg, index) => matchOnSubArg(arg, subjectToMatch[index]))
 
-    if (deepEqual(matchArgs[matchArgs.length - 1].value, []) && matchAllSubArgs) {
+    if (matchAllSubArgs && deepEqual(matchArgs[matchArgs.length - 1].value, [])) {
       return option.Some(subjectToMatch[0])
     }
 

--- a/tests/arrays.spec.js
+++ b/tests/arrays.spec.js
@@ -57,6 +57,26 @@ describe('arrays', () => {
     result.should.equal(10)
   })
 
+  it('should properly null elemnt on array when its not present', () => {
+    const result = matches([1, 2, 3])(
+      (x, y, xs, zs) => false,
+      (x = 1, y = null, z = 3, xs = []) => 11,
+      (x, xs) => 10
+    )
+
+    result.should.equal(10)
+  })
+
+  it('should properly null elemnt on array when its present', () => {
+    const result = matches([1, null, 3])(
+      (x, y, xs, zs) => false,
+      (x = 1, y = null, zs) => 11,
+      (x, xs) => 10
+    )
+
+    result.should.equal(11)
+  })
+
   it('should extract array from head when has tail argument', () => {
     const result = matches([1])(
       (x, y, xs) => false,

--- a/tests/arrays.spec.js
+++ b/tests/arrays.spec.js
@@ -47,6 +47,16 @@ describe('arrays', () => {
     result.should.deep.equal([1])
   })
 
+  it('should match on unspecified head with tail argument', () => {
+    const result = matches([1])(
+      (x, y, xs, zs) => false,
+      (x = 88, xs = []) => 11,
+      (x, xs = []) => 10
+    )
+
+    result.should.equal(10)
+  })
+
   it('should extract array from head when has tail argument', () => {
     const result = matches([1])(
       (x, y, xs) => false,


### PR DESCRIPTION
The previous behavior did not check the value on head, just that the last arg was an empty array. So, the added test will fail with the old implementation.

Also, see the message on `Update examples on README` commit.