### PR TITLE
Fix compress example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,14 @@ const compress = (numbers) => {
     (x, y, xs) => x === y
       ? compress([x].concat(xs))
       : [x].concat(compress([y].concat(xs))),
-    (x, xs) => x // stopping condition
+    (x, [y]) => x === y // stopping condition
+      ? [x]
+      : [x, y],
+    x => x
   )
 }
 
-compress([1, 1, 2, 3, 4, 4, 4]) //output: [1, 2, 3]
+compress([1, 1, 2, 3, 4, 4, 4]) //output: [1, 2, 3, 4]
 ```
 
 ### License


### PR DESCRIPTION
The current `compress` function of the README doesn't always return the expected value:

* with the given example (`[1, 1, 2, 3, 4, 4, 4]`) it actually output `[1,2,3,4]`, not `[1,2,3]` (which seems logical)
* with `[1,1,2,3,4]` the last element is missing (`[1,2,3]`)
* with a single-element or an empty list it returns `undefined`

This PR changes it so:

* `compress([1, 1, 2, 3, 4, 4, 4])` returns `[1, 2, 3, 4]`
* `compress([1, 1, 2, 3, 4])` also returns `[1, 2, 3, 4]`
* `compress([1, 1])` returns `[1]`
* `compress([1])` returns `[1]`
* `compress([])` returns `[]`