### PR TITLE
fix matchValue object type checking

### DIFF
--- a/src/match.js
+++ b/src/match.js
@@ -46,7 +46,12 @@ module.exports = (match, subjectToMatch) => {
   }
 
   // if is object (and not an array), check if contains
-  if (typeof subjectToMatch === 'object' && subjectToMatch !== null && !(subjectToMatch instanceof Array) && typeof matchValue === 'object') {
+  if (
+    typeof subjectToMatch === 'object' &&
+    subjectToMatch !== null &&
+    !(subjectToMatch instanceof Array) &&
+    matchValue.constructor === Object
+  ) {
     if (objectEquals(matchValue, subjectToMatch)) {
       return option.Some(subjectToMatch)
     }

--- a/tests/matches.spec.js
+++ b/tests/matches.spec.js
@@ -44,4 +44,12 @@ describe('matches', () => {
 
     result.should.equal(2)
   })
+
+  it('should match the correct object', () => {
+    const result = matches({ prop: 'value' })(
+      (x = [1, 2]) => false,
+      (x = { prop: 'value' }) => true
+    )
+    result.should.equal(true)
+  })
 })


### PR DESCRIPTION
`typeof matchValue === 'object'` returns true when the `matchvalue` is an array which reproduces this bug:

```
const result = matches({ data: 123 })(
  (x = [1, 2]) => 'Is array',
  (x = { data: 123 }) => 'is object'
)
// 'is array'
```

